### PR TITLE
feature: 개인정보 변경에 따른 토스트 구현

### DIFF
--- a/app/src/main/java/com/example/toyproject5/repository/UserRepository.kt
+++ b/app/src/main/java/com/example/toyproject5/repository/UserRepository.kt
@@ -92,7 +92,7 @@ class UserRepository @Inject constructor(
             if (response.isSuccessful && response.body() != null) {
                 val updatedData = response.body()!!
 
-                // TODO: 현재 예시에서는 닉네임만 저장하고 있지만, major 등도 저장
+                userDataStore.saveNickname(updatedData.nickname)
                 updatedData.major?.let { userDataStore.saveMajor(it) }
                 updatedData.bio?.let { userDataStore.saveBio(it) }
                 updatedData.profileImageUrl?.let { userDataStore.saveProfileImage(it) }

--- a/app/src/main/java/com/example/toyproject5/ui/screens/MyPageScreen.kt
+++ b/app/src/main/java/com/example/toyproject5/ui/screens/MyPageScreen.kt
@@ -67,6 +67,17 @@ fun MyPageScreen(pingViewModel: PingViewModel = hiltViewModel(),
         }
     }
 
+    // [추가] SharedFlow 이벤트 구독 (토스트 등)
+    LaunchedEffect(Unit) {
+        myPageViewModel.eventFlow.collect { event ->
+            when (event) {
+                is MyPageViewModel.MyPageEvent.ShowToast -> {
+                    android.widget.Toast.makeText(context, event.message, android.widget.Toast.LENGTH_SHORT).show()
+                }
+            }
+        }
+    }
+
     Scaffold(
         topBar = { MyPageHeader() }
     ) { innerPadding ->


### PR DESCRIPTION
개인 정보가 성공적으로 저장되었을 때, 실패할 때 Toast가 추가로 뜹니다. 
SharedFlow로 구현했는데, 기존 구현했던 방식이랑 다르긴 하네요... consistency가 조금 걸리긴 하지만 사소한 문제니 이렇게 PR 날리겠습니다.